### PR TITLE
allows module users to set the App Store's locale.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ jspm_packages
 .vscode/extensions.json
 
 jsconfig.json
+
+# c9
+.c9

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ AppLink.openInStore(appStoreId, playStoreId).then(() => {
 
 `config.appStoreId`: (String) the app's ID on the App Store (iOS). Example: `{ appStoreId: 'id529379082' }`
 
+`config.appStoreLocale`: (String) the App Store's locale (iOS). Defaults to the USA App Store. Example: `{ appStoreId: 'us' }`
+
 `config.playStoreId`: (String) the app's package identifier on the Play Store (Android). Example: `{ playStoreId: 'me.lyft.android' }`
 
 ---

--- a/index.js
+++ b/index.js
@@ -2,12 +2,16 @@ import { Linking, Platform } from 'react-native';
 
 export const maybeOpenURL = async (
   url,
-  { appName, appStoreId, playStoreId }
+  { appName, appStoreId, appStoreLocale, playStoreId }
 ) => {
   Linking.openURL(url).catch(err => {
     if (err.code === 'EUNSPECIFIED') {
       if (Platform.OS === 'ios') {
-        Linking.openURL(`https://itunes.apple.com/us/app/${appStoreId}`);
+        
+        // check if appStoreLocale is set
+        const locale = typeof appStoreLocale === 'undefined' ? 'us' : appStoreLocale;
+        
+        Linking.openURL(`https://itunes.apple.com/${locale}/app/${appStoreId}`);
       } else {
         Linking.openURL(
           `https://play.google.com/store/apps/details?id=${playStoreId}`


### PR DESCRIPTION
This config amendment allows for the setting of the App Store's locale. 

Use case:
End users with their locale set to 'ca' receive an error as they are directed to the USA App Store (us).


This pull request resolves this and enables for the setting of locale of any country. Additionally, there is no migration required as the locale defaults to 'us'. 

Please merge.