### PR TITLE
updated ios appstore links to account for url changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ export const maybeOpenURL = async (
 
 export const openInStore = async ({ appName, appStoreId, appStoreLocale = 'us', playStoreId }) => {
   if (Platform.OS === 'ios') {
-    Linking.openURL(`https://apps.apple.com/${locale}/app/${appName}/id${appStoreId}`);
+    Linking.openURL(`https://apps.apple.com/${appStoreLocale}/app/${appName}/id${appStoreId}`);
   } else {
     Linking.openURL(
       `https://play.google.com/store/apps/details?id=${playStoreId}`

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ export const maybeOpenURL = async (
           ? 'us'
           : appStoreLocale;
 
-        Linking.openURL(`https://itunes.apple.com/${locale}/app/${appName}/id${appStoreId}`);
+        Linking.openURL(`https://apps.apple.com/${locale}/app/${appName}/id${appStoreId}`);
       } else {
         Linking.openURL(
           `https://play.google.com/store/apps/details?id=${playStoreId}`
@@ -26,7 +26,7 @@ export const maybeOpenURL = async (
 
 export const openInStore = async ({ appName, appStoreId, appStoreLocale = 'us', playStoreId }) => {
   if (Platform.OS === 'ios') {
-    Linking.openURL(`https://itunes.apple.com/${appStoreLocale}/app/${appName}/id${appStoreId}`);
+    Linking.openURL(`https://apps.apple.com/${locale}/app/${appName}/id${appStoreId}`);
   } else {
     Linking.openURL(
       `https://play.google.com/store/apps/details?id=${playStoreId}`


### PR DESCRIPTION
Apple has updated the Appstore links, this accounts for the changes.

Also - the "locale" url is different than 'us'.  

https://apps.apple.com/il/app/lyft/id529379082

In this url it is 'il'. ***edit - I realized that the locale can change, some work and others don't***

I tested this new change, and it works great.

Thank you for creating this repo.