### PR TITLE
Added the possibility to open the app detail page in AppGallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </h3>
 
 <p align="center">
-Easily <a href="https://en.wikipedia.org/wiki/Mobile_deep_linking">deep link</a> to other apps in React Native. If the app isn't installed on the user's phone, open the App Store or Play Store link instead.
+Easily <a href="https://en.wikipedia.org/wiki/Mobile_deep_linking">deep link</a> to other apps in React Native. If the app isn't installed on the user's phone, open the App Store, Play Store or AppGallery link instead.
 </p>
 
 ---
@@ -35,14 +35,14 @@ Easily <a href="https://en.wikipedia.org/wiki/Mobile_deep_linking">deep link</a>
 ```javascript
 import AppLink from 'react-native-app-link';
 
-AppLink.maybeOpenURL(url, { appName, appStoreId, appStoreLocale, playStoreId }).then(() => {
+AppLink.maybeOpenURL(url, { appName, appStoreId, appStoreLocale, playStoreId, appGalleryId }).then(() => {
   // do stuff
 })
 .catch((err) => {
   // handle error
 });
 
-AppLink.openInStore({ appName, appStoreId, appStoreLocale, playStoreId }).then(() => {
+AppLink.openInStore({ appName, appStoreId, appStoreLocale, playStoreId, appGalleryId }).then(() => {
   // do stuff
 })
 .catch((err) => {
@@ -52,7 +52,7 @@ AppLink.openInStore({ appName, appStoreId, appStoreLocale, playStoreId }).then((
 
 ## API:
 
-### `maybeOpenURL(url, config) -> Promise` Opens link if app is present. If not, it opens an app store to prompt the user to download it. 
+### `maybeOpenURL(url, config) -> Promise` Opens link if app is present. If not, it opens an app store to prompt the user to download it.
 
 `url`: (String) a url in the specified app's [deep linking](https://en.wikipedia.org/wiki/Mobile_deep_linking) format that points to the content you want to open.
 
@@ -62,13 +62,15 @@ AppLink.openInStore({ appName, appStoreId, appStoreLocale, playStoreId }).then((
 
 `config.appStoreId`: (String) the app's ID on the App Store (iOS). Example: `{ appStoreId: '529379082' }`
 
-`config.appStoreLocale`: (String) the App Store's locale (iOS). Defaults to the USA App Store. Example: `{ appStoreId: 'us' }`
+`config.appStoreLocale`: (String) the App Store's locale (iOS). Defaults to the USA App Store. Example: `{ appStoreLocale: 'us' }`
 
 `config.playStoreId`: (String) the app's package identifier on the Play Store (Android). Example: `{ playStoreId: 'me.lyft.android' }`
 
+`config.appGalleryId`: (String) the app's ID on the AppGallery (Android). Example: `{ appGalleryId: '100170981' }`
+
 ---
 
-### `openInStore(config) -> Promise` Opens an app store to the listing requested. 
+### `openInStore(config) -> Promise` Opens an app store to the listing requested.
 
 `config`: (Object) a config for generate store urls.
 
@@ -79,5 +81,7 @@ AppLink.openInStore({ appName, appStoreId, appStoreLocale, playStoreId }).then((
 `config.appStoreLocale`: (String) the App Store's locale (iOS). Defaults to the USA App Store. Example: `{ appStoreLocale: 'us' }`
 
 `config.playStoreId`: (String) the app's package identifier on the Play Store (Android). Example: `{ playStoreId: 'me.lyft.android' }`
+
+`config.appGalleryId`: (String) the app's ID on the AppGallery (Android). Example: `{ appGalleryId: '100170981' }`
 
 > If there are any issues file an issue above and don't hesitate to spin up a PR and contribute!

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ import { Linking, Platform } from 'react-native';
 
 export const maybeOpenURL = async (
   url,
-  { appName, appStoreId, appStoreLocale, playStoreId }
+  { appName, appStoreId, appStoreLocale, playStoreId, appGalleryId = null }
 ) => {
   Linking.openURL(url).catch(err => {
     if (err.code === 'EUNSPECIFIED') {
@@ -14,9 +14,23 @@ export const maybeOpenURL = async (
 
         Linking.openURL(`https://itunes.apple.com/${locale}/app/${appName}/id${appStoreId}`);
       } else {
-        Linking.openURL(
-          `https://play.google.com/store/apps/details?id=${playStoreId}`
-        );
+        if(appGalleryId != null) {
+          Linking.openURL(
+            `hiapplink://com.huawei.appmarket?appId=C${appGalleryId}`
+          ).catch(err => {
+              console.log(err)
+              if(err.code == 'EUNSPECIFIED') {
+                Linking.openURL(
+                  `https://play.google.com/store/apps/details?id=${playStoreId}`
+                );
+              }
+          })
+        }
+        else {
+          Linking.openURL(
+            `https://play.google.com/store/apps/details?id=${playStoreId}`
+          );
+        }
       }
     } else {
       throw new Error(`Could not open ${appName}. ${err.toString()}`);
@@ -24,13 +38,27 @@ export const maybeOpenURL = async (
   });
 };
 
-export const openInStore = async ({ appName, appStoreId, appStoreLocale = 'us', playStoreId }) => {
+export const openInStore = async ({ appName, appStoreId, appStoreLocale = 'us', playStoreId, appGalleryId = null }) => {
   if (Platform.OS === 'ios') {
     Linking.openURL(`https://itunes.apple.com/${appStoreLocale}/app/${appName}/id${appStoreId}`);
   } else {
-    Linking.openURL(
-      `https://play.google.com/store/apps/details?id=${playStoreId}`
-    );
+    if(appGalleryId != null) {
+      Linking.openURL(
+        `hiapplink://com.huawei.appmarket?appId=C${appGalleryId}`
+      ).catch(err => {
+          console.log(err)
+          if(err.code == 'EUNSPECIFIED') {
+            Linking.openURL(
+              `https://play.google.com/store/apps/details?id=${playStoreId}`
+            );
+          }
+      })
+    }
+    else {
+      Linking.openURL(
+        `https://play.google.com/store/apps/details?id=${playStoreId}`
+      );
+    }
   }
 };
 


### PR DESCRIPTION
First of all, thank you for creating react-native-app-link.
It is used by many developers to open their apps' detail page on the App Store or the Play Store.

As you likely already know, the new Huawei Android-powered devices (starting from the P40 and Mate 30 Series) do not come with the Play Store preinstalled. This has lead to the increase in popularity of Huawei's own application store, called the AppGallery.

Many developers using your library might already have uploaded their applications to the AppGallery. It would be nice if these developers had the ability to redirect users to their app's detail page on the AppGallery as well.

The changes I made here will allow developers to additionally provide their app's "appGalleryId" to the **maybeOpenURL()** and **openInStore()** functions. If AppGallery is not installed on the user's Android device, the Play Store link will be opened instead.
If the developer does not provide the "appGalleryId" parameter, the Play Store link will be opened like before.

This is an approach that seems to work. I thought of other approaches, like checking which application stores are installed on the device to decide which application store to open, but that would require adding extra dependencies to react-native-app-link, which I tried to avoid.

Please let me know if you agree with this change or if you think it could be done better.